### PR TITLE
DOM tree Visitor pattern

### DIFF
--- a/mkr-1/Interfaces/ILightNodeVisitor.cs
+++ b/mkr-1/Interfaces/ILightNodeVisitor.cs
@@ -1,0 +1,10 @@
+﻿using mkr_1.Nodes;
+
+namespace mkr_1.Interfaces
+{
+    public interface ILightNodeVisitor
+    {
+        void VisitElement(LightElementNode element);
+        void VisitText(LightTextNode textNode);
+    }
+}

--- a/mkr-1/Nodes/LightElementNode.cs
+++ b/mkr-1/Nodes/LightElementNode.cs
@@ -78,6 +78,15 @@ namespace mkr_1.Nodes
                 return $"<{TagName}{classAttribute}>{InnerHTML}</{TagName}>";
             }
         }
+
+        public override void Accept(ILightNodeVisitor visitor)
+        {
+            visitor.VisitElement(this);
+            foreach (var child in Children)
+            {
+                child.Accept(visitor);
+            }
+        }
     }
 
 }

--- a/mkr-1/Nodes/LightNode.cs
+++ b/mkr-1/Nodes/LightNode.cs
@@ -1,4 +1,6 @@
-﻿namespace mkr_1.Nodes
+﻿using mkr_1.Interfaces;
+
+namespace mkr_1.Nodes
 {
     public abstract class LightNode
     {
@@ -10,5 +12,7 @@
 
         public abstract string OuterHTML { get; }
         public abstract string InnerHTML { get; }
+
+        public abstract void Accept(ILightNodeVisitor visitor);
     }
 }

--- a/mkr-1/Nodes/LightTextNode.cs
+++ b/mkr-1/Nodes/LightTextNode.cs
@@ -1,4 +1,6 @@
-﻿namespace mkr_1.Nodes
+﻿using mkr_1.Interfaces;
+
+namespace mkr_1.Nodes
 {
     public class LightTextNode : LightNode
     {
@@ -24,6 +26,11 @@
         }
 
         public override string InnerHTML => OuterHTML;
+
+        public override void Accept(ILightNodeVisitor visitor)
+        {
+            visitor.VisitText(this);
+        }
     }
 
 }

--- a/mkr-1/Program.cs
+++ b/mkr-1/Program.cs
@@ -2,11 +2,14 @@
 using mkr_1.Enums;
 using mkr_1.Nodes;
 using mkr_1.States;
+using mkr_1.Visitors;
+using System.Text;
 
 public class Program
 {
     public static void Main()
     {
+        Console.OutputEncoding = Encoding.UTF8;
         // task1
         var ul = new LoggingElementNode("ul", DisplayType.Block, TagType.Paired);
         ul.AddCssClass("list");
@@ -69,5 +72,22 @@ public class Program
         Console.WriteLine("\nDisabled:");
         Console.WriteLine(div.OuterHTML);
 
+        // task5
+        div.AddCssClass("main");
+
+        var span = new LightElementNode("span", DisplayType.Inline, TagType.Paired);
+        span.AddCssClass("highlight");
+        span.Children.Add(new LightTextNode("Hello!"));
+
+        div.Children.Add(span);
+
+        var collector = new CssClassCollector();
+        div.Accept(collector);
+
+        Console.WriteLine("CSS класи в дереві:");
+        foreach (var cls in collector.Classes)
+        {
+            Console.WriteLine($" - {cls}");
+        }
     }
 }

--- a/mkr-1/Visitors/CssClassCollector.cs
+++ b/mkr-1/Visitors/CssClassCollector.cs
@@ -1,0 +1,23 @@
+﻿using mkr_1.Interfaces;
+using mkr_1.Nodes; 
+
+namespace mkr_1.Visitors
+{
+    public class CssClassCollector : ILightNodeVisitor
+    {
+        public HashSet<string> Classes { get; } = new();
+
+        public void VisitElement(LightElementNode element)
+        {
+            foreach (var css in element.CssClasses)
+            {
+                Classes.Add(css);
+            }
+        }
+
+        public void VisitText(LightTextNode textNode)
+        {
+        }
+    }
+
+}


### PR DESCRIPTION
Added the Visitor pattern to apply operations across different types of DOM nodes. Introduced a CssClassCollector as an example visitor to collect CSS classes from all elements. Improves separation of operations and structure.